### PR TITLE
adding functionality for users to update password

### DIFF
--- a/client/pages/settings.js
+++ b/client/pages/settings.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { auth } from '../utils/firebase';
 import AvatarChangeModal from '../components/AvatarChangeModal';
 import Navbar from '@/components/Navbar/Navbar';
+import Link from 'next/link';
 import { useDarkMode } from '../utils/darkModeContext';
 import styles from '../styles/settings.module.css';
 
@@ -124,6 +125,13 @@ const Settings = () => {
                 <button onClick={handleAvatarChangeClick} className={styles.uploadButton}>
                     Upload Your Avatar
                 </button>
+                <div  className={styles.container}>
+                    <button className={styles.uploadButton}>
+                        <Link href="/update-password" className='text-light link-secondary link-underline-opacity-0'>
+                            Update Your Password
+                        </Link>
+                    </button>
+                </div>
             </div>
         </div>
     );

--- a/client/pages/update-password.js
+++ b/client/pages/update-password.js
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { auth } from '../utils/firebase';
+import { sendPasswordResetEmail } from 'firebase/auth';
+import axios from 'axios';
+import Link from 'next/link';
+import Image from "next/image"; 
+import logo from '../assets/images/logo.png';
+import { getAuth, updatePassword } from "firebase/auth";
+import { useDarkMode } from '@/utils/darkModeContext';
+
+const UpdatePassword = () => {
+    const [username, setUsername] = useState('');
+    const [currentPassword, setcurrentPassword] = useState('');
+    const [updatedPassword, setupdatedPassword] = useState('');
+    const [error, setError] = useState(null);
+    const [isAlertVisible, setIsAlertVisible] = useState(false);
+    const [updatedPasswordRef, setPasswordRef] = useState('');
+    const [user, setUser] = useState(null);
+    const [userData, setUserData] = useState(null);
+    const { isDarkMode } = useDarkMode();
+
+    const closeModal = () => {
+        setEditorOpen(false);
+        setSelectedFile(null);
+        setScaleValue(1);
+    };
+
+    const handleUpdatePassword = async (e) => {
+        e.preventDefault();
+        const auth = getAuth();
+        const user = auth.currentUser;
+        
+        // await updatePassword(user, currentPassword, updatedPassword, updatedPasswordRef).then(() => {
+        //     axios.post(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/users/changePassword`, { currentPassword, updatedPassword, updatedPasswordRef })
+        // });
+        
+        updatePassword(user, updatedPassword).then(() => {
+            console.log('Password updated successfully');
+        }).catch((error) => {
+            console.log('Password couldn\'t be updated');
+        });
+    };
+
+    return (
+        <div className="container">
+            <div className="row mt-5 justify-content-md-center">
+                <div className="col col-md-4 col-sm-12">
+                    <div className="d-flex justify-content-center">
+                        <Image src={logo} alt="logo"/>
+                    </div>
+
+                    <h2 className="m-4 text-center">Update Password</h2>
+
+                    { error && 
+                        <p className='text-center text-danger'>{error}</p>
+                    }
+
+                    { isAlertVisible &&  
+                        <div className="alert alert-success text-center" role="alert">
+                           { alert }
+                        </div>
+                    }
+                    
+                    <form onSubmit={handleUpdatePassword}>
+                        <div className="form-group mb-3">
+                            <label className="mb-1" htmlFor="exampleInputEmail1">New Password</label>
+                            <input
+                                type="password"
+                                placeholder="password"
+                                value={updatedPassword}
+                                className="form-control"
+                                onChange={(e) => setupdatedPassword(e.target.value)}
+                            />                        
+                        </div>
+                    </form>
+                    
+                    <div className='text-center mt-4'>
+                        <Link href="/login" className="link-dark link-offset-2">Back to Login</Link> 
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+    
+}
+
+export default UpdatePassword;

--- a/client/pages/update-password.js
+++ b/client/pages/update-password.js
@@ -1,45 +1,39 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
-import { auth } from '../utils/firebase';
-import { sendPasswordResetEmail } from 'firebase/auth';
 import axios from 'axios';
 import Link from 'next/link';
 import Image from "next/image"; 
 import logo from '../assets/images/logo.png';
 import { getAuth, updatePassword } from "firebase/auth";
-import { useDarkMode } from '@/utils/darkModeContext';
 
 const UpdatePassword = () => {
-    const [username, setUsername] = useState('');
-    const [currentPassword, setcurrentPassword] = useState('');
     const [updatedPassword, setupdatedPassword] = useState('');
+    const [confirmUpdatedPassword, setConfirmedPassword] = useState('');
     const [error, setError] = useState(null);
     const [isAlertVisible, setIsAlertVisible] = useState(false);
-    const [updatedPasswordRef, setPasswordRef] = useState('');
-    const [user, setUser] = useState(null);
-    const [userData, setUserData] = useState(null);
-    const { isDarkMode } = useDarkMode();
-
-    const closeModal = () => {
-        setEditorOpen(false);
-        setSelectedFile(null);
-        setScaleValue(1);
-    };
+    const router = useRouter(); // Initialize useRouter hook
 
     const handleUpdatePassword = async (e) => {
         e.preventDefault();
         const auth = getAuth();
         const user = auth.currentUser;
-        
-        // await updatePassword(user, currentPassword, updatedPassword, updatedPasswordRef).then(() => {
-        //     axios.post(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/users/changePassword`, { currentPassword, updatedPassword, updatedPasswordRef })
-        // });
-        
-        updatePassword(user, updatedPassword).then(() => {
-            console.log('Password updated successfully');
-        }).catch((error) => {
-            console.log('Password couldn\'t be updated');
-        });
+
+        if (updatedPassword.length < 6) {
+            // alert("Password should be at least 6 characters");
+            setError("Password should be at least 6 characters");
+        } else if (updatedPassword === confirmUpdatedPassword) {
+            updatePassword(user, updatedPassword).then(() => {
+                console.log('Password updated successfully');
+                alert("Password updated successfully");
+                router.push('/settings');
+            }).catch((error) => {
+                console.log('Password couldn\'t be updated');
+            });
+        } else {
+            // in case password field doesn't match the confirm password field it will show an error message
+            // alert("Passwords don't match");
+            setError("Passwords don't match");
+        }
     };
 
     return (
@@ -67,16 +61,31 @@ const UpdatePassword = () => {
                             <label className="mb-1" htmlFor="exampleInputEmail1">New Password</label>
                             <input
                                 type="password"
-                                placeholder="password"
+                                placeholder="Password"
                                 value={updatedPassword}
                                 className="form-control"
                                 onChange={(e) => setupdatedPassword(e.target.value)}
                             />                        
                         </div>
+
+                        <div className="form-group mb-3">
+                            <label className="mb-1" htmlFor="exampleInputPassword1">Confirm New Password</label>
+                            <input
+                                type="password"
+                                placeholder="Confirm New Password"
+                                value={confirmUpdatedPassword}
+                                className="form-control"
+                                onChange={(e) => setConfirmedPassword(e.target.value)}
+                            />                    
+                        </div>
+
+                        <div className='text-center mt-4'>
+                            <button type="submit" className="btn btn-secondary">Update Password</button>
+                        </div>
                     </form>
                     
                     <div className='text-center mt-4'>
-                        <Link href="/login" className="link-dark link-offset-2">Back to Login</Link> 
+                        <Link href="/settings" className="link-dark link-offset-2">Back to Settings</Link> 
                     </div>
                 </div>
             </div>

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -39,6 +39,16 @@ router.route('/usernameCheck')
         }
     })
 
+// change user password
+router.route('/changePassword')
+    .post(async(req, res) => {
+        try {
+
+        } catch (error) {
+
+        }
+    })
+
 //Get all Users
 router.route('/')
     .get(async (req, res) => {

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -43,7 +43,7 @@ router.route('/usernameCheck')
 router.route('/changePassword')
     .post(async(req, res) => {
         try {
-
+            const { currentPassword, updatedPassword, updatedPasswordRef } = req.body;
         } catch (error) {
 
         }


### PR DESCRIPTION
Changes:
- Adds `update-password.js` file for users
  - Allows users to update their password
  - Validates password input by user, requires matching confirmation of input
  - Users are routed back to the settings page after successfully updating password
-  Updates `settings.js` with link to update password page

To Test:
- Run `npm run dev` in `client` and `server` directories and view webpage at http://localhost:3000/ 
- Create an account and navigate to settings page to update password