### PR TITLE
UI logic

### DIFF
--- a/server/routes/sharedCardsets.js
+++ b/server/routes/sharedCardsets.js
@@ -66,6 +66,7 @@ router.route('/:cardsetid/share')
                     res.status(409).json('User already has access to the cardset');
                     return;
                 }
+                //
                 const sharedCardset = await cardset.addSharedWithUser(user, {
                     through: { authority: req.query.authority },
                     attributes: ['id']


### PR DESCRIPTION
1. removed the delete button on cardset if the viewer is not creator .
2. cross check auto refresh for explore button when you click it.
3. removed the viewer access share if the cardset is already public and add it again if it's private.